### PR TITLE
chore(gitignore): include vs code plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,6 +240,9 @@ FakesAssemblies/
 **/*.Server/ModelManifest.xml
 _Pvt_Extensions
 
+# Visual Studio Code plugins
+.ionide
+
 # Paket dependency manager
 .paket/paket.exe
 paket-files/


### PR DESCRIPTION
Include .ionide folder, which is a VS Code plugin, to the .gitignore set.
